### PR TITLE
Add missing dependency "brick/math"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "ext-mbstring": "*",
         "beberlei/assert": "^3.2",
         "fgrosse/phpasn1": "^2.0",
-        "spomky-labs/base64url": "^1.0|^2.0"
+        "spomky-labs/base64url": "^1.0|^2.0",
+        "brick/math": "^0.8 || ^0.9",
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
Even though it's used here: https://github.com/web-token/jwt-key-mgmt/commit/adafc9f5b23f8853f9a01fc31804e6a91561bdc3#diff-45063750c023c9b2e8884edbd223ad82R54 the dependancy is not defined

I see its defined in the framework (https://github.com/web-token/jwt-framework) but not here